### PR TITLE
cleaning includes after extracting metadata program

### DIFF
--- a/bindings/java/xmipp_Projection.cpp
+++ b/bindings/java/xmipp_Projection.cpp
@@ -1,13 +1,15 @@
-#include "xmipp_java_adapter.h"
+//#include "xmipp_java_adapter.h"
 #include <jni.h>
 #include "xmipp_Projection.h"
-#include "xmipp_ImageGeneric.h"
+//#include "xmipp_ImageGeneric.h"
 #include "xmipp_ExceptionsHandler.h"
 #include "xmipp_InternalData.h"
-#include <core/xmipp_image.h>
-#include <data/projection.h>
-#include <data/filters.h>
-#include <core/geometry.h>
+#include "core/xmipp_image.h"
+#include "core/matrix2d.h"
+#include "data/fourier_projection.h"
+#include "data/projection.h"
+#include "data/filters.h"
+#include "core/geometry.h"
 /*
 JNIEXPORT void JNICALL Java_xmipp_jni_Projection_projectVolume
 (JNIEnv *env, jclass class_, jobject jvolume, jobject jprojection, jdouble rot, jdouble tilt, jdouble psi)


### PR DESCRIPTION
Extracting metadata program (and few other classes to break the dependencies) - step towards extracting SQL.
Also further speeds up build (under 7 minutes now)
This PR has two dependencies:
I2PC/xmipp#325
https://github.com/I2PC/xmippCore/pull/68