### PR TITLE
Fixing old installation compatibility issue

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -266,7 +266,7 @@ install_jar(
 
 # Install java libraries
 install(
-	DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}/java/lib/
+	FILES ${JAVA_JARS}
 	DESTINATION ${JAVA_LIB_INSTALL_DIR}
 )
 install(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,17 @@ file(
 		${CMAKE_CURRENT_SOURCE_DIR}/java/lib/*.jar
 )
 
+# Remove JAR files from the old installer
+foreach(JAR_FILE IN LISTS JAVA_JARS)
+	get_filename_component(BASENAME ${JAR_FILE} NAME)
+    if(BASENAME MATCHES "^Xmipp")
+		message(WARNING "${JAR_FILE} is probably from an old installation. Please, consider deleting it.")
+	else()
+        list(APPEND CURATED_JAVA_JARS ${JAR_FILE})
+    endif()
+endforeach()
+set(JAVA_JARS ${CURATED_JAVA_JARS})
+
 # Create the shared library
 add_library(XmippJNI SHARED ${JNI_SOURCES})
 #target_precompile_headers(


### PR DESCRIPTION
Old installer placed some compilation artifacts in `java/lib` directory. The new installer copies the contents from this directory into the final destination. Thus, the newly compiled artifacts get overwritten by the old ones. The changes proposed in this PR check the filenames of the contents in `java/lib`. If any of them matches "Xmipp", they are not copied and a warning is issued requesting the user to delete those files.

How to test:

1. In case there is none, place one or more files whose name starts with `Xmipp` in `java/lib`. For instance `XmippErrorTest.jar`
2. Run the installer
3. Ensure that a warning is issue for each file that matches the previous pattern
4. Ensure that they are not copied to `dist/bindings/java/lib/`