### PR TITLE
Add dynamically updated major version tag

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,6 +24,15 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         custom_tag: ${{ steps.variables.outputs.TAG_NAME }}
+    
+    - name: Update major version tag
+      run: |
+        VERSION=${{ steps.variables.outputs.TAG_NAME }}
+        MAJOR=${VERSION%%.*}
+        git config --global user.name 'GitHub Actions'
+        git config --global user.email 'action@github.com'
+        git tag -fa "${MAJOR}" -m 'Update major version tag with $VERSION'
+        git push origin "${MAJOR}" --force
         
     - name: Create a GitHub release
       uses: ncipollo/release-action@main


### PR DESCRIPTION
This is a tag with the name of the latest major version, that will automatically be updated with every new release.

For example, if the latest tag is `v3.24.0`, a tag `v3` will be created with the same content of `v3.24.0`.
If then, tag `v3.24.0.1` is released, tag `v3` will be automatically updated so that its content matches the one of the newly created tag.
If tag `v4.0.0` is created, a new tag `v4` will be generated as a new major release.

This will allow cloning `v3` tag to automatically get the latest release within major version `3`, and so on, allowing an easy way of handling dependency updates without triggering releases in repositories that depend on this one.