### PR TITLE
Fix Java version check in CMake to support Java 8 and newer distributions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -25,7 +25,12 @@ cmake_minimum_required(VERSION 3.16)
 include(GNUInstallDirs)
 
 # Find dependencies
-find_package(Java 8 REQUIRED)
+find_package(Java REQUIRED)
+if(Java_VERSION VERSION_LESS "1.8")
+    message(FATAL_ERROR "Java 8 or newer is required")
+endif()
+
+
 find_package(JNI REQUIRED)
 include(UseJava)
 


### PR DESCRIPTION
Replace find_package(Java 8 REQUIRED) with a generic Java detection and a proper version comparison using Java_VERSION VERSION_LESS "1.8". This avoids incorrect version parsing of Java 8 update releases (e.g., 1.8.0_472) that were being rejected despite being valid Java 8 installations.

E.g. error:

> CMake Error at /data/cryo-em/manual_processing/fpdeisidro/app/CMake/Modules/FindPackageHandleStandardArgs.cmake:233 (message):
>   Could NOT find Java: Found unsuitable version "1.8.0.472", but required is
>   at least "8" (found /usr/bin/java)